### PR TITLE
update name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "olivier127/rbac-bundle",
+    "name": "sctr/rbac-bundle",
     "type": "symfony-bundle",
     "description": "Symfony PhpRabcBundle allow to use RBAC control access for symfony project",
     "keywords": [


### PR DESCRIPTION
Before:
```
composer require olivier127/rbac-bundle
```

After:
```
composer require sctr/rbac-bundle
```

The 1st command pulls from our private repo so long as client `composer.json` includes an entry in `repositories`:
```
    "repositories": [
        {
            "type": "vcs",
            "url": "git@github.com:sctr/rbac-bundle.git"
        }
    ]
```

However, the 2nd command also pulls from our private repo but seems clearer.